### PR TITLE
Changed two small documentation issues

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -119,7 +119,7 @@ A config block can be provided in your environment files or initializers.
 Example showing defaults:
 
   ActsAsIndexed.configure do |config|
-    config.index_file = [RAILS_ROOT,'index'] 
+    config.index_file = [Rails.root.to_s,'index'] 
     config.index_file_depth = 3
     config.min_word_size = 3
   end


### PR DESCRIPTION
Further I'd recommend this:

```
  config.index_file = [Rails.root.to_s, 'tmp/acts_as_indexed']
```

as its transparent to the user, should work well, and is imho the right place compared to just 'index'
