### PR TITLE
Storage#lock_file fails on JRuby

### DIFF
--- a/lib/acts_as_indexed/storage.rb
+++ b/lib/acts_as_indexed/storage.rb
@@ -169,7 +169,7 @@ module ActsAsIndexed #:nodoc:
     def lock_file(file_path, &block) # :nodoc:
       # Windows does not support file locking.
       if !windows? && file_path.exist?
-        file_path.open('r') do |f|
+        file_path.open('r+') do |f|
           begin
             f.flock File::LOCK_EX
             yield


### PR DESCRIPTION
lock_file fails on JRuby with:

Errno::EBADF: Bad file descriptor - cannot acquire exclusive lock on File not opened for write
