### PR TITLE
I think we should always use Rails.root.join('tmp', 'index') as the default place to store the marshaled index files.

### DIFF
--- a/lib/acts_as_indexed/configuration.rb
+++ b/lib/acts_as_indexed/configuration.rb
@@ -30,7 +30,7 @@ module ActsAsIndexed
     # Set to true to enable.
     # Default is false.
     attr_accessor :case_sensitive
-    
+
     # Disable indexing, useful for large test suites.
     # Set to false to disable.
     # Default is false.
@@ -78,11 +78,7 @@ module ActsAsIndexed
     private
 
     def default_index_file
-      if Rails.root.writable?
-        Rails.root.join('index')
-      else
-        Rails.root.join('tmp', 'index')
-      end
+      Rails.root.join('tmp', 'index')
     end
 
   end


### PR DESCRIPTION
What do you think? Frequently people ask "what's this index directory?" so this is in response to that.. 

Thanks!
