### PR TITLE
Call .underscore on a model name

### DIFF
--- a/lib/acts_as_indexed/class_methods.rb
+++ b/lib/acts_as_indexed/class_methods.rb
@@ -52,7 +52,7 @@ module ActsAsIndexed
       end
 
       # Add the Rails environment and this model's name to the index file path.
-      self.aai_config.index_file = self.aai_config.index_file.join(Rails.env, self.name)
+      self.aai_config.index_file = self.aai_config.index_file.join(Rails.env, self.name.underscore)
     end
 
     # Adds the passed +record+ to the index. Index is built if it does not already exist. Clears the query cache.


### PR DESCRIPTION
Call .underscore on a model name because we don't want namespaced models to create folders like module::class. It will be module/class instead.
