### PR TITLE
Added support for site with several locales

### DIFF
--- a/lib/acts_as_indexed/search_index.rb
+++ b/lib/acts_as_indexed/search_index.rb
@@ -9,7 +9,7 @@ module ActsAsIndexed #:nodoc:
     # fields:: Fields or instance methods of ActiveRecord model to be indexed.
     # config:: ActsAsIndexed::Configuration instance.
     def initialize(fields, config)
-      @storage = Storage.new(Pathname.new(config.index_file.to_s), config.index_file_depth)
+      @storage = Storage.new(Pathname.new(config.index_file.to_s + "/" + I18n.locale.to_s), config.index_file_depth)
       @fields = fields
       @atoms = {}
       @min_word_size = config.min_word_size


### PR DESCRIPTION
I am using Globalize3 and noticed that acts_as_indexed didn't work correctly for my multi-lingual site.

The problem was that if I started with locale :en and made a search, it indexed all the translated fields for english. But if I then changed language to :sv and made a different search it didn't re-index and I only got hits for the search phrase on the previously indexed english hits. This fix will add a folder with the locale to each model so that you will be able to index correctly.

Don't know if it should be a merge to the main project (due to the I18n dependency) but might be a nice branch if someone else has the same problem.
