### PR TITLE
id => object_id

### DIFF
--- a/lib/acts_as_indexed/class_methods.rb
+++ b/lib/acts_as_indexed/class_methods.rb
@@ -174,10 +174,10 @@ module ActsAsIndexed
     def sort(ranked_records)
       ranked_records.sort { |a, b|
         a_score = a.last
-        a_id = a.first.is_a?(Fixnum) ? a.first : a.first.id
+        a_id = a.first.is_a?(Fixnum) ? a.first : a.first.object_id
 
         b_score = b.last
-        b_id = b.first.is_a?(Fixnum) ? b.first : b.first.id
+        b_id = b.first.is_a?(Fixnum) ? b.first : b.first.object_id
 
         if a_score == b_score
           a_id <=> b_id


### PR DESCRIPTION
I was getting an error about :id not being defined for string.  I saw that id is deprecated on object for object_id and I changed it, and it fixed my problem.
