### PR TITLE
Ensure that thread is required when using Mutex on Ruby 1.8.7

### DIFF
--- a/lib/acts_as_indexed/storage.rb
+++ b/lib/acts_as_indexed/storage.rb
@@ -1,3 +1,5 @@
+require 'thread'
+
 module ActsAsIndexed #:nodoc:
   class Storage
 


### PR DESCRIPTION
This used to be loaded by, I believe, Rake but not anymore.

My tests were failing only on Ruby 1.8.7:
https://travis-ci.org/refinery/refinerycms-acts-as-indexed/jobs/4297230/#L139
