### PR TITLE
Fix exception when using offsets past the result size.

### DIFF
--- a/lib/acts_as_indexed/class_methods.rb
+++ b/lib/acts_as_indexed/class_methods.rb
@@ -124,7 +124,8 @@ module ActsAsIndexed
         # slice up the results by offset and limit
         offset = find_options[:offset] || 0
         limit = find_options.include?(:limit) ? find_options[:limit] : @query_cache[query].size
-        part_query = sort(@query_cache[query]).slice(offset,limit).map{ |r| r.first }
+        sorted_and_sliced_results = sort(@query_cache[query]).slice(offset, limit)
+        part_query = sorted_and_sliced_results ? sorted_and_sliced_results.map{ |r| r.first } : []
 
         # Set these to nil as we are dealing with the pagination by setting
         # exactly what records we want.

--- a/test/integration/acts_as_indexed_test.rb
+++ b/test/integration/acts_as_indexed_test.rb
@@ -143,10 +143,14 @@ class ActsAsIndexedTest < ActiveSupport::TestCase
     # offset
     assert_equal [4, 5], Post.find_with_index('^cr', { :offset => 1 }, :ids_only => true)
     assert_equal [4, 5], Post.find_with_index('^cr', { :offset => 1 }).map{ |r| r.id }
+    assert_equal [], Post.find_with_index('^cr', { :offset => 4 }, :ids_only => true)
+    assert_equal [], Post.find_with_index('^cr', { :offset => 4 }).map{ |r| r.id }
 
     # limit and offset
     assert_equal [4], Post.find_with_index('^cr', { :limit => 1, :offset => 1 }, :ids_only => true)
     assert_equal [4], Post.find_with_index('^cr', { :limit => 1, :offset => 1 }).map{ |r| r.id }
+    assert_equal [], Post.find_with_index('^cr', { :limit => 1, :offset => 4 }, :ids_only => true)
+    assert_equal [], Post.find_with_index('^cr', { :limit => 1, :offset => 4 }).map{ |r| r.id }
 
     # order
     assert_equal [6,5,4,3,2,1], Post.find_with_index('^c', { :order => 'id desc' }).map{ |r| r.id }

--- a/test/integration/will_paginate_search_test.rb
+++ b/test/integration/will_paginate_search_test.rb
@@ -14,6 +14,7 @@ class WillPaginateSearchTest < ActiveSupport::TestCase
     assert_equal [5, 2, 1, 3, 6, 4], paginate_search(1, 10)
     assert_equal [5, 2, 1], paginate_search(1, 3)
     assert_equal [3, 6, 4], paginate_search(2, 3)
+    assert_equal [], paginate_search(2, 7)
   end
 
   private


### PR DESCRIPTION
[This line](https://github.com/dougal/acts_as_indexed/blob/0.8.3/lib/acts_as_indexed/class_methods.rb#L127) raises with "undefined method `map' for nil:NilClass" if the offset goes beyond the result set, for example if a high page number is specified while trying to paginate.
