### PR TITLE
Give option to return both record & rank

### DIFF
--- a/lib/acts_as_indexed/class_methods.rb
+++ b/lib/acts_as_indexed/class_methods.rb
@@ -149,7 +149,15 @@ module ActsAsIndexed
              ranked_records[r] = @query_cache[query][r.id]
            end
 
-           sort(ranked_records.to_a).map{ |r| r.first }
+           sorted_records = sort(ranked_records.to_a)
+
+           if options.include?(:include_rank)
+             sorted_records.map do |r|
+               {record: r.first, rank: r.second}
+             end
+           else
+             sorted_records.map{ |r| r.first }   #Remove the rank
+           end
          end
       end
 

--- a/lib/acts_as_indexed/class_methods.rb
+++ b/lib/acts_as_indexed/class_methods.rb
@@ -97,7 +97,9 @@ module ActsAsIndexed
     # ====options
     # ids_only:: Method returns an array of integer IDs when set to true.
     # no_query_cache:: Turns off the query cache when set to true. Useful for testing.
-
+    # include_rank:: If set to true then this returns the hash with the record
+    #                and the rank. Otherwise it just returns the record object.
+    #                Default is false.
     def search_index(query, find_options={}, options={})
 
       # Clear the query cache off  if the key is set.
@@ -151,9 +153,9 @@ module ActsAsIndexed
 
            sorted_records = sort(ranked_records.to_a)
 
-           if options.include?(:include_rank)
+           if options[:include_rank]
              sorted_records.map do |r|
-               {record: r.first, rank: r.second}
+               { record: r.first, rank: r.second }
              end
            else
              sorted_records.map{ |r| r.first }   #Remove the rank

--- a/test/integration/acts_as_indexed_test.rb
+++ b/test/integration/acts_as_indexed_test.rb
@@ -131,6 +131,15 @@ class ActsAsIndexedTest < ActiveSupport::TestCase
     run_queries(queries)
   end
 
+  def test_queries_return_rank
+    result = Post.find_with_index('crane', {}, {include_rank: true});
+    assert_equal 2, result.length
+    assert_not_nil result.first[:record]
+    assert_not_nil result.first[:rank]
+
+    assert_equal 2, result.first[:rank].floor
+    assert_equal 1, result.second[:rank].floor
+  end
 
   # NOTE: This test always fails for Rails 2.3. A bug somewhere in either
   #       Rails or the SQLite adaptor which causes the offset to be ignored.

--- a/test/integration/acts_as_indexed_test.rb
+++ b/test/integration/acts_as_indexed_test.rb
@@ -132,7 +132,7 @@ class ActsAsIndexedTest < ActiveSupport::TestCase
   end
 
   def test_queries_return_rank
-    result = Post.find_with_index('crane', {}, {include_rank: true});
+    result = Post.find_with_index('crane', {}, { include_rank: true });
     assert_equal 2, result.length
     assert_not_nil result.first[:record]
     assert_not_nil result.first[:rank]


### PR DESCRIPTION
If you want to do a search over multiple models then you need the ranking number returned with each result.
