### PR TITLE
Use an ActiveRecord relation for search results.

### DIFF
--- a/lib/acts_as_indexed/class_methods.rb
+++ b/lib/acts_as_indexed/class_methods.rb
@@ -203,6 +203,18 @@ module ActsAsIndexed
         super
       end
 
+      # Override count/size to return the total search results, not the sliced count
+      def count(column_name = nil)
+        return super if column_name
+        return super unless ranked_ids
+        ranked_ids.size
+      end
+
+      def size
+        return super unless ranked_ids
+        ranked_ids.size
+      end
+
       private
 
       def apply_ranked_ordering!

--- a/lib/acts_as_indexed/class_methods.rb
+++ b/lib/acts_as_indexed/class_methods.rb
@@ -27,12 +27,7 @@ module ActsAsIndexed
       before_update :update_index
       after_destroy :remove_from_index
 
-      # scope for Rails 3.x, named_scope for Rails 2.x.
-      if self.respond_to?(:where)
-        scope :with_query, lambda { |query| where("#{table_name}.#{primary_key} IN (?)", search_index(query, {}, {:ids_only => true})) }
-      else
-        named_scope :with_query, lambda { |query| { :conditions => ["#{table_name}.#{primary_key} IN (?)", search_index(query, {}, {:ids_only => true}) ] } }
-      end
+      scope :with_query, lambda { |query| where("#{table_name}.#{primary_key} IN (?)", search_index(query, {}, {:ids_only => true})) }
 
       unless respond_to?(:aai_fields) && respond_to?(:aai_config)
         cattr_accessor :aai_config, :aai_fields
@@ -169,26 +164,70 @@ module ActsAsIndexed
 
       sort(ranked_records.to_a).map{ |r| r.first }
 
-      # Old way, deprecated and broken.
-      # with_scope :find => find_options do
-      #   # Doing the find like this eliminates the possibility of errors occuring
-      #   # on either missing records (out-of-sync) or an empty results array.
-      #   records = find(:all, :conditions => [ "#{table_name}.#{primary_key} IN (?)", part_query])
-      #
-      #   if find_options.include?(:order)
-      #     records # Just return the records without ranking them.
-      #
-      #   else
-      #     # Results come back in random order from SQL, so order again.
-      #     ranked_records = ActiveSupport::OrderedHash.new
-      #     records.each do |r|
-      #       ranked_records[r] = @query_cache[query][r.id]
-      #     end
-      #
-      #     sort(ranked_records.to_a).map{ |r| r.first }
-      #   end
-      # end
+    end
 
+    # NEW 2026 way to search that returns an ActiveRecord::Relation instead of an array.
+    # This allows for chaining of other query methods. This method uses an extension to
+    # apply the relevance ranking at execution time, which allows it to work with limit
+    # and offset without needing to slice the ranked IDs in Ruby or sending a large number
+    # of IDs in the SQL query.
+    def search_relation(query, options = {})
+      build_index
+
+      results = (@query_cache ||= {})[query] ||= new_index.search(query)
+
+      ids = sort(results).map { |r| r.first }
+      return none if ids.empty?
+
+      # Extend the relation with ranking behavior that optimizes at execution time
+      relation = all.extending(RankedRelationExtension)
+      relation.ranked_ids = ids
+      relation.model_table_name = table_name
+      relation.model_primary_key = primary_key
+      
+      relation
+    end
+
+    # Module to extend relations with ranked search behavior
+    module RankedRelationExtension
+      attr_accessor :ranked_ids, :model_table_name, :model_primary_key
+
+      def load
+        # Apply optimized ranking before executing the query
+        if ranked_ids && !loaded?
+          apply_ranked_ordering!
+        end
+        super
+      end
+
+      private
+
+      def apply_ranked_ordering!
+        # Determine which IDs we actually need based on limit/offset
+        offset = offset_value || 0
+        limit = limit_value || ranked_ids.size
+        
+        # Slice to only the IDs needed for this query
+        sliced_ids = ranked_ids.slice(offset, limit) || []
+        
+        return unless sliced_ids.any?
+
+        # Apply WHERE clause with only the needed IDs
+        where!("#{model_table_name}.#{model_primary_key} IN (?)", sliced_ids)
+
+        # Build CASE statement for ranking (only for sliced IDs)
+        # Cast to Integer to prevent SQL injection from corrupt index files
+        order_clause = "CASE #{sliced_ids.each_with_index.map { |id, i|
+          "WHEN #{model_table_name}.#{model_primary_key}=#{Integer(id)} THEN #{i}"
+        }.join(' ')} END"
+        
+        order!(Arel.sql(order_clause))
+
+        # Clear limit/offset since we already sliced the IDs
+        # This prevents double-application of limit/offset
+        offset!(nil)
+        limit!(nil)
+      end
     end
 
     # Builds an index from scratch for the current model class.

--- a/lib/acts_as_indexed/class_methods.rb
+++ b/lib/acts_as_indexed/class_methods.rb
@@ -167,11 +167,14 @@ module ActsAsIndexed
     end
 
     # NEW 2026 way to search that returns an ActiveRecord::Relation instead of an array.
-    # This allows for chaining of other query methods. This method uses an extension to
-    # apply the relevance ranking at execution time, which allows it to work with limit
-    # and offset without needing to slice the ranked IDs in Ruby or sending a large number
-    # of IDs in the SQL query.
-    def search_relation(query, options = {})
+    # Returns a chainable ActiveRecord relation with results ranked by relevance.
+    # Uses an extension to apply ranking at execution time, optimizing the CASE
+    # statement based on limit/offset values.
+    #
+    # ====Examples
+    #   Post.search('ruby rails').limit(10)
+    #   Post.search('tutorial').where(published: true).order(:created_at)
+    def search(query, options = {})
       build_index
 
       results = (@query_cache ||= {})[query] ||= new_index.search(query)

--- a/lib/acts_as_indexed/class_methods.rb
+++ b/lib/acts_as_indexed/class_methods.rb
@@ -185,6 +185,7 @@ module ActsAsIndexed
       # Extend the relation with ranking behavior that optimizes at execution time
       relation = all.extending(RankedRelationExtension)
       relation.ranked_ids = ids
+      relation.total_search_results = ids.size  # Store original count before any slicing
       relation.model_table_name = table_name
       relation.model_primary_key = primary_key
       
@@ -193,7 +194,7 @@ module ActsAsIndexed
 
     # Module to extend relations with ranked search behavior
     module RankedRelationExtension
-      attr_accessor :ranked_ids, :model_table_name, :model_primary_key
+      attr_accessor :ranked_ids, :model_table_name, :model_primary_key, :total_search_results
 
       def load
         # Apply optimized ranking before executing the query
@@ -206,13 +207,13 @@ module ActsAsIndexed
       # Override count/size to return the total search results, not the sliced count
       def count(column_name = nil)
         return super if column_name
-        return super unless ranked_ids
-        ranked_ids.size
+        return super unless total_search_results
+        total_search_results
       end
 
       def size
-        return super unless ranked_ids
-        ranked_ids.size
+        return super unless total_search_results
+        total_search_results
       end
 
       private


### PR DESCRIPTION
This PR does two things:
1. Removes support from Rails < 3.
2. Adds a more modern relation for searching.

The problem is that **with_query** sends all the resulting IDs in every request, which can make for huge requests. The options in **search_index** will slice the ids, sure, but then you lose the ability to chain options naturally.

## Add `.search()` method for chainable, optimized relation queries

### Problem
- `with_query` returns a relation but sends ALL matching IDs in the SQL query (`WHERE id IN (1000s of IDs)`), creating massive queries
- `search_index` can slice IDs via limit/offset options, but returns an array, losing ActiveRecord chainability

### Solution
This PR adds a new `.search()` method that returns a chainable `ActiveRecord::Relation` while optimizing the SQL query size. It uses a relation extension that intercepts query execution to:
1. Apply limit/offset to slice the ranked IDs *before* building the SQL
2. Generate a minimal CASE statement with only the needed IDs
3. Preserve relevance ranking via SQL ORDER BY

### Benefits
- **Chainable**: `.search('query').where(...).limit(10).includes(...)`
- **Optimized**: Only sends needed IDs in the CASE statement, not all matches
- **Ranked**: Maintains relevance ordering from the search index

### Example
```ruby
# Returns page 2 with only 4 IDs in the CASE statement, not 1000s
Animanga.search('anime').where(published: true).offset(4).limit(4)

# SQL generated:
# SELECT * FROM animangas 
# WHERE (published = true) AND (animangas.id IN (135, 166, 442, 634))
# ORDER BY CASE WHEN animangas.id=135 THEN 0 
#               WHEN animangas.id=166 THEN 1 
#               WHEN animangas.id=442 THEN 2 
#               WHEN animangas.id=634 THEN 3 END
```

Let me know if you notice any issues with this.